### PR TITLE
parallel remote deployment and teardown

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,23 @@
 # Development Notes
 
 ## Setup
+
 - [ ] Pull the latest `-local` version from `main`
 - [ ] Pull the latest `-src` version from `main` and build their container images and push to docker.io.
 - [ ] After the images have been built, modify the asset names in the remote stack within `-local` to match the link given in docker.io. Note: this is done in two lines in the remote stack `.ts` file.
-- [ ] Attend to: 
-	- [ ] config.json to ensure that you have the correct configurations for the test. IE: Home region, remote region, Duration, VUs per region
-	- [ ] script.js to ensure that you are running the correct test script. 
+- [ ] Attend to:
+  - [ ] config.json to ensure that you have the correct configurations for the test. IE: Home region, remote region, Duration, VUs per region
+  - [ ] script.js to ensure that you are running the correct test script.
 
 ## Deployment
+
 - [ ] To only deploy the home region, use `npm run deploy:home` command. This deploys the necessary home components and populates the components with necessary initial states
 - [ ] To fully deploy with the remote regions, use `npm run deploy:all` command. This deploys the home and the remote regions
+- [ ] Note: if you have more than one remote region, use `npm run deploy:parallel:all` and `npm run destroy:parallel:all`
 
 ## Teardown
-- [ ] To teardown just the home region, use `npm run destroy:home` - appropriate if only interacting with the home region. 
+
+- [ ] To teardown just the home region, use `npm run destroy:home` - appropriate if only interacting with the home region.
 - [ ] To teardown the remote region, use `npm run destroy:all` - appropriate if you also built a remote region.
 
 # Orchestrator Workflow

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "test": "jest",
     "cdk": "cdk",
     "bootstrap": "cd ./src/aws && cdk bootstrap && cd ../..",
-		"visualize": "node frontend/server.js",
+    "visualize": "node frontend/server.js",
     "install:orchestrator": "cd ./src/aws/lambda/orchestrator && npm install && cd ../../../..",
     "deploy:home:awsonly": "npm run bootstrap && npm run install:orchestrator && cd ./src/aws && cdk deploy \"*Home*\" && cd ../..",
     "destroy:home:awsonly": "cd ./src/aws && cdk destroy -f \"*Home*\" && cd ../..",
@@ -21,7 +21,9 @@
     "deploy:home": "npm run deploy:home:awsonly && npm run deploy:scripts",
     "destroy:home": "npm run destroy:scripts && npm run destroy:home:awsonly",
     "deploy:all": "npm run deploy:home && npm run deploy:remote:awsonly",
-    "destroy:all": "npm run destroy:remote:awsonly && npm run destroy:home"
+    "destroy:all": "npm run destroy:remote:awsonly && npm run destroy:home",
+    "deploy:parallel:all": "npm run deploy:home && node ./src/scripts/deployRemoteInfraParallel.js",
+    "destroy:parallel:all": "node ./src/scripts/destroyRemoteInfraParallel.js && npm run destroy:home"
   },
   "devDependencies": {
     "@types/jest": "^27.5.2",

--- a/src/aws/lib/constellation-remote-stack.ts
+++ b/src/aws/lib/constellation-remote-stack.ts
@@ -110,7 +110,7 @@ export class ConstellationRemoteStack extends Stack {
     const testerService = new ecs.FargateService(this, 'constellation-tester-service', {
       cluster: cluster,
       taskDefinition: testerTaskDef,
-      desiredCount: 1, // change to >1 when ready
+      desiredCount: 3, // change to >1 when ready
     })
   }
 }

--- a/src/config.json
+++ b/src/config.json
@@ -2,6 +2,7 @@
   "DURATION": 2000,
   "HOME_REGION": "us-east-1",
   "REMOTE_REGIONS": {
-    "us-east-2": 20
+    "ca-central-1": 20,
+    "eu-west-3": 10
   }
 }

--- a/src/scripts/deployRemoteInfraParallel.js
+++ b/src/scripts/deployRemoteInfraParallel.js
@@ -1,0 +1,19 @@
+/**
+ * This script is used to deploy the **remote** infrastructure in parallel!
+ */
+
+const { sh } = require("./utils/sh");
+const path = require("path");
+const config = require("./configParser");
+const REMOTE_REGIONS = Object.keys(config.REMOTE_REGIONS);
+
+const deployRemoteInfraParallel = async () => {
+  const awsPath = path.resolve(__dirname, "..", "aws");
+  const commands = REMOTE_REGIONS.map(
+    (region) => `(cd ${awsPath} && cdk deploy -f \"*${region}*\")`
+  );
+  const shellPromises = commands.map((command) => sh(command));
+  await Promise.all(shellPromises);
+};
+
+deployRemoteInfraParallel();

--- a/src/scripts/destroyRemoteInfraParallel.js
+++ b/src/scripts/destroyRemoteInfraParallel.js
@@ -1,0 +1,19 @@
+/**
+ * This script is used to destroy the **remote** infrastructure in parallel!
+ */
+
+const { sh } = require("./utils/sh");
+const path = require("path");
+const config = require("./configParser");
+const REMOTE_REGIONS = Object.keys(config.REMOTE_REGIONS);
+
+const destroyRemoteInfraParallel = async () => {
+  const awsPath = path.resolve(__dirname, "..", "aws");
+  const commands = REMOTE_REGIONS.map(
+    (region) => `(cd ${awsPath} && cdk destroy -f \"*${region}*\")`
+  );
+  const shellPromises = commands.map((command) => sh(command));
+  await Promise.all(shellPromises);
+};
+
+destroyRemoteInfraParallel();

--- a/src/scripts/utils/sh.js
+++ b/src/scripts/utils/sh.js
@@ -1,0 +1,33 @@
+const childProcess = require("child_process");
+
+const sh = async (cmd) => {
+  return new Promise((resolve, reject) => {
+    const child = childProcess.exec(cmd);
+    // streams the output to the console
+    child.stdout.pipe(process.stdout);
+    child.stderr.pipe(process.stderr);
+
+    // close and exit are used for redundancy
+    child.on("close", (code) => {
+      if (code === 0) {
+        resolve();
+      } else {
+        reject(`child process closed with code ${code}`);
+      }
+      console.log(`child process closed with code ${code}`);
+    });
+
+    child.on("exit", (code) => {
+      resolve();
+      console.log(`child process exited with code ${code}`);
+    });
+
+    child.on("error", (err) => {
+      reject(`child process exited with error ${err}`);
+    });
+  });
+};
+
+module.exports = {
+  sh,
+};


### PR DESCRIPTION
functionality is provided for parallelized deployment and teardown of remote regions **ONLY**

and documentation is added to README to reflect new dev commands. 
- `npm run deploy:parallel:all`, and `npm run destroy:parallel:all`

old dev commands remain in place for convenience
- `npm run deploy:all` and `npm run destroy:all`
